### PR TITLE
fix: ajustar recursos e timeout do rollout

### DIFF
--- a/.github/workflows/ci-cd-eks.yml
+++ b/.github/workflows/ci-cd-eks.yml
@@ -185,7 +185,7 @@ jobs:
           echo "⏳ Waiting for deployment rollout..."
           kubectl rollout status deployment/${{ env.K8S_DEPLOYMENT }} \
             -n ${{ env.K8S_NAMESPACE }} \
-            --timeout=10m
+            --timeout=5m
 
       - name: Verify Deployment
         run: |

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -55,8 +55,8 @@ spec:
         
         resources:
           requests:
-            memory: "512Mi"
-            cpu: "500m"
+            memory: "128Mi"
+            cpu: "100m"
           limits:
-            memory: "512Mi"
-            cpu: "500m"
+            memory: "256Mi"
+            cpu: "200m"


### PR DESCRIPTION
- Reduzir resources: 512Mi/500m → 128Mi/100m (requests)
- Reduzir limits: 512Mi/500m → 256Mi/200m
- Restaurar Wait for Rollout com timeout de 5 minutos
- Resolver problema de Insufficient memory no cluster